### PR TITLE
Resolve compiler warnings on Windows and macOS

### DIFF
--- a/src/c2dec.c
+++ b/src/c2dec.c
@@ -54,7 +54,7 @@ int main(int argc, char *argv[])
     unsigned char *bits;
     float         *softdec_bits;
     char          *bitperchar_bits;
-    int            nsam, nbit, nbyte, i, byte, frames, bits_proc, bit_errors, error_mode;
+    int            nsam, nbit, nbyte, i, byte, bits_proc, bit_errors, error_mode;
     int            nstart_bit, nend_bit, bit_rate;
     int            state, next_state;
     float          ber, r, burst_length, burst_period, burst_timer, ber_est;
@@ -173,7 +173,7 @@ int main(int argc, char *argv[])
     bits = (unsigned char*)malloc(nbyte*sizeof(char));
     softdec_bits = (float*)malloc(nbit*sizeof(float));
     bitperchar_bits = (char*)malloc(nbit*sizeof(char));
-    frames = bit_errors = bits_proc = 0;
+    bit_errors = bits_proc = 0;
     nstart_bit = 0;
     nend_bit = nbit-1;
 
@@ -256,8 +256,6 @@ int main(int argc, char *argv[])
     }
 
     while(ret) {
-	frames++;
-
         // apply bit errors, MSB of byte 0 is bit 0 in frame, only works in packed mode
 
 	if ((error_mode == UNIFORM) || (error_mode == UNIFORM_RANGE)) {

--- a/src/cohpsk_mod.c
+++ b/src/cohpsk_mod.c
@@ -55,7 +55,7 @@ int main(int argc, char *argv[])
     int           tx_bits[2*COHPSK_BITS_PER_FRAME];
     COMP          tx_fdm[COHPSK_NOM_SAMPLES_PER_FRAME];
     short         tx_fdm_scaled[COHPSK_NOM_SAMPLES_PER_FRAME];
-    int           frames, diversity;
+    int           diversity;
     int           i;
 
     if (argc < 3) {
@@ -91,10 +91,7 @@ int main(int argc, char *argv[])
     }
     fprintf(stderr, "diversity: %d\n", diversity);
 
-    frames = 0;
-
     while(fread(tx_bits_char, sizeof(char), COHPSK_BITS_PER_FRAME*diversity, fin) == COHPSK_BITS_PER_FRAME*diversity) {
-        frames++;
 
         for(i=0; i<COHPSK_BITS_PER_FRAME*diversity; i++)
             tx_bits[i] = tx_bits_char[i];

--- a/src/fdmdv_mod.c
+++ b/src/fdmdv_mod.c
@@ -46,7 +46,6 @@ int main(int argc, char *argv[])
     int           *tx_bits;
     COMP          tx_fdm[2*FDMDV_NOM_SAMPLES_PER_FRAME];
     short         tx_fdm_scaled[2*FDMDV_NOM_SAMPLES_PER_FRAME];
-    int           frames;
     int           i, bit, byte;
     int           sync_bit;
     int           bits_per_fdmdv_frame;
@@ -105,10 +104,7 @@ int main(int argc, char *argv[])
     foff_phase_rect.real = 1.0; foff_phase_rect.imag = 0.0;
 #endif
 
-    frames = 0;
-
     while(fread(packed_bits, sizeof(char), bytes_per_codec_frame, fin) == bytes_per_codec_frame) {
-	frames++;
 
 	/* unpack bits, MSB first */
 

--- a/src/fsk_demod.c
+++ b/src/fsk_demod.c
@@ -359,7 +359,7 @@ int main(int argc,char *argv[]){
                 fprintf(stderr,"{");
                 time_t seconds  = time(NULL);
 
-                fprintf(stderr,"\"secs\": %ld, \"EbNodB\": %5.1f, \"ppm\": %4d,",seconds, stats.snr_est, (int)fsk->ppm);
+                fprintf(stderr,"\"secs\": %ld, \"EbNodB\": %5.1f, \"ppm\": %4d,",(long)seconds, stats.snr_est, (int)fsk->ppm);
                 float *f_est;
                 if (fsk->freq_est_type)
                     f_est = fsk->f2_est;

--- a/unittest/tfreedv_2400A_rawdata.c
+++ b/unittest/tfreedv_2400A_rawdata.c
@@ -74,7 +74,6 @@ int main(int argc, char **argv)
 
     printf("freedv_rawdatatx()/freedv_rawdatarx() ");
     int frames = 0;
-    int fails = 0;
     {
         short mod[nom_samples * 10];
 	/* Note: A codec frame is only 6.5 bytes!
@@ -94,7 +93,6 @@ int main(int argc, char **argv)
                 for (b = 0; b < 7; b++) {
 	    	    if (payload[b] != payload_rx[b]) {
 		        printf("Received codec bits 0x%02x do not match expected 0x%02x\n", payload_rx[b], payload[b]);
-		        fails++;
                     }
                 }
 	        frames++;

--- a/unittest/tfreedv_2400B_rawdata.c
+++ b/unittest/tfreedv_2400B_rawdata.c
@@ -74,7 +74,6 @@ int main(int argc, char **argv)
 
     printf("freedv_rawdatatx()/freedv_rawdatarx() ");
     int frames = 0;
-    int fails = 0;
     {
         short mod[nom_samples * 10];
 	/* Note: A codec frame is only 6.5 bytes!
@@ -94,7 +93,6 @@ int main(int argc, char **argv)
                 for (b = 0; b < 7; b++) {
 	    	    if (payload[b] != payload_rx[b]) {
 		        printf("Received codec bits 0x%02x do not match expected 0x%02x\n", payload_rx[b], payload[b]);
-		        fails++;
                     }
                 }
 	        frames++;

--- a/unittest/tquisk_filter.c
+++ b/unittest/tquisk_filter.c
@@ -25,7 +25,6 @@ int main() {
     complex float buf[N];
     struct quisk_cfFilter *bpf; 
     int           i;
-    int           n = 0;
     
     bpf = malloc(sizeof(struct quisk_cfFilter));
     assert(bpf != NULL);
@@ -39,7 +38,7 @@ int main() {
         /* we only output the real part in this test */
         for(i=0; i<N; i++)
             buf_short[i] = creal(buf[i]);
-        n += fwrite(buf_short, sizeof(short), N, stdout);
+        fwrite(buf_short, sizeof(short), N, stdout);
     }
     
     quisk_filt_destroy(bpf);


### PR DESCRIPTION
I encountered the following warnings on both macOS and Windows (using LLVM MinGW for the latter):

```
[ 41%] Building C object src/CMakeFiles/c2dec.dir/c2dec.c.obj
/home/mooneer/freedv-gui/build_win_x86_64/codec2_src/src/c2dec.c:57:48: warning: variable 'frames' set but not used [-Wunused-but-set-variable]
    int            nsam, nbit, nbyte, i, byte, frames, bits_proc, bit_errors, error_mode;
                                               ^
1 warning generated.

[ 46%] Building C object src/CMakeFiles/fdmdv_mod.dir/fdmdv_mod.c.obj
/home/mooneer/freedv-gui/build_win_x86_64/codec2_src/src/fdmdv_mod.c:49:19: warning: variable 'frames' set but not used [-Wunused-but-set-variable]
    int           frames;
                  ^
1 warning generated.

/home/mooneer/freedv-gui/build_win_x86_64/codec2_src/src/fsk_demod.c:362:82: warning: format specifies type 'long' but the argument has type 'time_t' (aka 'long long') [-Wformat]
                fprintf(stderr,"\"secs\": %ld, \"EbNodB\": %5.1f, \"ppm\": %4d,",seconds, stats.snr_est, (int)fsk->ppm);
                                          ~~~                                    ^~~~~~~
                                          %lld
1 warning generated.

/home/mooneer/freedv-gui/build_win_x86_64/codec2_src/src/cohpsk_mod.c:58:19: warning: variable 'frames' set but not used [-Wunused-but-set-variable]
    int           frames, diversity;
                  ^
1 warning generated.

/Users/mooneer/devel/codec2/unittest/ofdm_stack.c:94:23: warning: passing arguments to 'dummy_code' without a prototype is deprecated in all versions of C and is not supported in C2x [-Wdeprecated-non-prototype]
            dummy_code(tx_bits, rx_bits);
                      ^
/Users/mooneer/devel/codec2/unittest/ofdm_stack.c:30:6: warning: a function declaration without a prototype is deprecated in all versions of C and is not supported in C2x [-Wdeprecated-non-prototype]
void dummy_code();
     ^
                void
/Users/mooneer/devel/codec2/unittest/ofdm_stack.c:220:6: warning: a function declaration without a prototype is deprecated in all versions of C and is not supported in C2x [-Wdeprecated-non-prototype]
void dummy_code(int tx_bits[], int rx_bits[]) {
     ^
3 warnings generated.


/Users/mooneer/devel/codec2/unittest/tfreedv_2400A_rawdata.c:77:9: warning: variable 'fails' set but not used [-Wunused-but-set-variable]
    int fails = 0;
        ^
1 warning generated.

/Users/mooneer/devel/codec2/unittest/tfreedv_2400B_rawdata.c:77:9: warning: variable 'fails' set but not used [-Wunused-but-set-variable]
    int fails = 0;
        ^
1 warning generated.

/Users/mooneer/devel/codec2/unittest/tquisk_filter.c:28:19: warning: variable 'n' set but not used [-Wunused-but-set-variable]
    int           n = 0;
                  ^
                  
/Users/mooneer/devel/codec2/misc/tnlp.c:52:5: warning: a function declaration without a prototype is deprecated in all versions of C and is not supported in C2x [-Wdeprecated-non-prototype]
int switch_present(sw,argc,argv)
  ^
1 warning generated.

/Users/mooneer/devel/codec2/misc/timpulse.c:105:8: warning: variable 'e' set but not used [-Wunused-but-set-variable]
        float e = 0.0;
              ^
1 warning generated.
```

This PR cleans up those warnings as appropriate.